### PR TITLE
Get frame

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -72,9 +72,27 @@ class _ExampleMainWindowState extends State<_ExampleMainWindow> {
                       'args3': true,
                       'bussiness': 'bussiness_test',
                     }));
+                    // window
+                    //   ..setFrame(const Offset(0, 0) & const Size(1280, 720))
+                    //   ..center()
+                    //   ..setTitle('Another window')
+                    //   ..show();
+                    await window
+                        .setFrame(const Offset(0, 0) & const Size(1280, 720));
+                    {
+                      final rect = await window.getFrame();
+                      debugPrint(
+                        'REMOVE ME =========================== (${rect.left}, ${rect.right}, ${rect.top}, ${rect.bottom})',
+                      );
+                    }
+                    await window.center();
+                    {
+                      final rect = await window.getFrame();
+                      debugPrint(
+                        'REMOVE ME =========================== (${rect.left}, ${rect.right}, ${rect.top}, ${rect.bottom})',
+                      );
+                    }
                     window
-                      ..setFrame(const Offset(0, 0) & const Size(1280, 720))
-                      ..center()
                       ..setTitle('Another window')
                       ..show();
                   },

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -72,27 +72,9 @@ class _ExampleMainWindowState extends State<_ExampleMainWindow> {
                       'args3': true,
                       'bussiness': 'bussiness_test',
                     }));
-                    // window
-                    //   ..setFrame(const Offset(0, 0) & const Size(1280, 720))
-                    //   ..center()
-                    //   ..setTitle('Another window')
-                    //   ..show();
-                    await window
-                        .setFrame(const Offset(0, 0) & const Size(1280, 720));
-                    {
-                      final rect = await window.getFrame();
-                      debugPrint(
-                        'REMOVE ME =========================== (${rect.left}, ${rect.right}, ${rect.top}, ${rect.bottom})',
-                      );
-                    }
-                    await window.center();
-                    {
-                      final rect = await window.getFrame();
-                      debugPrint(
-                        'REMOVE ME =========================== (${rect.left}, ${rect.right}, ${rect.top}, ${rect.bottom})',
-                      );
-                    }
                     window
+                      ..setFrame(const Offset(0, 0) & const Size(1280, 720))
+                      ..center()
                       ..setTitle('Another window')
                       ..show();
                   },

--- a/lib/src/window_controller.dart
+++ b/lib/src/window_controller.dart
@@ -55,6 +55,11 @@ abstract class WindowController {
   /// Set the window frame rect.
   Future<void> setFrame(Rect frame);
 
+  /// Get the window frame rect.
+  Future<Rect> getFrame() async {
+    return Future.value(Rect.zero);
+  }
+
   /// Center the window on the screen.
   Future<void> center();
 

--- a/lib/src/window_controller_impl.dart
+++ b/lib/src/window_controller_impl.dart
@@ -50,6 +50,23 @@ class WindowControllerMainImpl extends WindowController {
   }
 
   @override
+  Future<Rect> getFrame() async {
+    final Map<String, dynamic> arguments = {
+      'windowId': _id,
+    };
+    final Map<dynamic, dynamic> resultData = await _channel.invokeMethod(
+      'getFrame',
+      arguments,
+    );
+    return Rect.fromLTWH(
+      resultData['x'],
+      resultData['y'],
+      resultData['width'],
+      resultData['height'],
+    );
+  }
+
+  @override
   Future<void> setTitle(String title) {
     return _channel.invokeMethod('setTitle', <String, dynamic>{
       'windowId': _id,

--- a/linux/base_flutter_window.cc
+++ b/linux/base_flutter_window.cc
@@ -55,8 +55,8 @@ void BaseFlutterWindow::SetBounds(double_t x, double_t y, double_t width,
                     static_cast<gint>(height));
 }
 
-g_autoptr(FlValue) BaseFlutterWindow::GetBounds() {
-  g_autoptr(FlValue) result_data = fl_value_new_map();
+FlValue* BaseFlutterWindow::GetBounds() {
+  FlValue* result_data = fl_value_new_map();
   auto window = GetWindow();
   if (window) {
     gint x, y, width, height;

--- a/linux/base_flutter_window.cc
+++ b/linux/base_flutter_window.cc
@@ -55,6 +55,22 @@ void BaseFlutterWindow::SetBounds(double_t x, double_t y, double_t width,
                     static_cast<gint>(height));
 }
 
+g_autoptr(FlValue) BaseFlutterWindow::GetBounds() {
+  g_autoptr(FlValue) result_data = fl_value_new_map();
+  auto window = GetWindow();
+  if (window) {
+    gint x, y, width, height;
+    gtk_window_get_position(GTK_WINDOW(window), &x, &y);
+    gtk_window_get_size(GTK_WINDOW(window), &width, &height);
+
+    fl_value_set_string_take(result_data, "x", fl_value_new_float(x));
+    fl_value_set_string_take(result_data, "y", fl_value_new_float(y));
+    fl_value_set_string_take(result_data, "width", fl_value_new_float(width));
+    fl_value_set_string_take(result_data, "height", fl_value_new_float(height));
+  }
+  return result_data;
+}
+
 void BaseFlutterWindow::SetTitle(const std::string &title) {
   auto window = GetWindow();
   if (!window) {

--- a/linux/base_flutter_window.h
+++ b/linux/base_flutter_window.h
@@ -32,7 +32,7 @@ public:
   void SetTitle(const std::string &title);
 
   void SetBounds(double_t x, double_t y, double_t width, double_t height);
-  g_autoptr(FlValue) GetBounds();
+  FlValue* GetBounds();
 
   void Center();
 

--- a/linux/base_flutter_window.h
+++ b/linux/base_flutter_window.h
@@ -32,6 +32,7 @@ public:
   void SetTitle(const std::string &title);
 
   void SetBounds(double_t x, double_t y, double_t width, double_t height);
+  g_autoptr(FlValue) GetBounds();
 
   void Center();
 

--- a/linux/desktop_multi_window_plugin.cc
+++ b/linux/desktop_multi_window_plugin.cc
@@ -62,6 +62,11 @@ static void desktop_multi_window_plugin_handle_method_call(
     auto height = fl_value_get_float(fl_value_lookup_string(args, "height"));
     MultiWindowManager::Instance()->SetFrame(window_id, left, top, width, height);
     response = FL_METHOD_RESPONSE(fl_method_success_response_new(nullptr));
+  } else if (strcmp(method, "getFrame") == 0) {
+    auto *args = fl_method_call_get_args(method_call);
+    auto window_id = fl_value_get_int(fl_value_lookup_string(args, "windowId"));
+    auto result = MultiWindowManager::Instance()->GetFrame(window_id);
+    response = FL_METHOD_RESPONSE(fl_method_success_response_new(result));
   } else if (strcmp(method, "setTitle") == 0) {
     auto *args = fl_method_call_get_args(method_call);
     auto window_id = fl_value_get_int(fl_value_lookup_string(args, "windowId"));

--- a/linux/desktop_multi_window_plugin.cc
+++ b/linux/desktop_multi_window_plugin.cc
@@ -65,7 +65,7 @@ static void desktop_multi_window_plugin_handle_method_call(
   } else if (strcmp(method, "getFrame") == 0) {
     auto *args = fl_method_call_get_args(method_call);
     auto window_id = fl_value_get_int(fl_value_lookup_string(args, "windowId"));
-    auto result = MultiWindowManager::Instance()->GetFrame(window_id);
+    g_autoptr(FlValue) result = MultiWindowManager::Instance()->GetFrame(window_id);
     response = FL_METHOD_RESPONSE(fl_method_success_response_new(result));
   } else if (strcmp(method, "setTitle") == 0) {
     auto *args = fl_method_call_get_args(method_call);

--- a/linux/multi_window_manager.cc
+++ b/linux/multi_window_manager.cc
@@ -164,15 +164,17 @@ void MultiWindowManager::SetFrame(int64_t id, double x, double y, double width, 
   UNLOCK_WINDOW;
 }
 
-g_autoptr(FlValue) MultiWindowManager::GetFrame(int64_t id) {
+FlValue* MultiWindowManager::GetFrame(int64_t id) {
+  FlValue* frame = NULL;
   RLOCK_WINDOW;
   auto window = windows_.find(id);
   if (window != windows_.end()) {
-    return window->second->SetBounds();
+    frame = window->second->GetBounds();
   } else {
-    return fl_value_new_map();
+    frame = fl_value_new_map();
   }
   UNLOCK_WINDOW;
+  return frame;
 }
 
 void MultiWindowManager::SetTitle(int64_t id, const std::string &title) {

--- a/linux/multi_window_manager.cc
+++ b/linux/multi_window_manager.cc
@@ -164,6 +164,17 @@ void MultiWindowManager::SetFrame(int64_t id, double x, double y, double width, 
   UNLOCK_WINDOW;
 }
 
+g_autoptr(FlValue) MultiWindowManager::GetFrame(int64_t id) {
+  RLOCK_WINDOW;
+  auto window = windows_.find(id);
+  if (window != windows_.end()) {
+    return window->second->SetBounds();
+  } else {
+    return fl_value_new_map();
+  }
+  UNLOCK_WINDOW;
+}
+
 void MultiWindowManager::SetTitle(int64_t id, const std::string &title) {
   RLOCK_WINDOW;
   auto window = windows_.find(id);

--- a/linux/multi_window_manager.h
+++ b/linux/multi_window_manager.h
@@ -39,6 +39,7 @@ class MultiWindowManager : public std::enable_shared_from_this<MultiWindowManage
   void SetFullscreen(int64_t id, bool fullscreen);
 
   void SetFrame(int64_t id, double_t x, double_t y, double_t width, double_t height);
+  g_autoptr(FlValue) GetFrame();
 
   void Center(int64_t id);
 

--- a/linux/multi_window_manager.h
+++ b/linux/multi_window_manager.h
@@ -39,7 +39,7 @@ class MultiWindowManager : public std::enable_shared_from_this<MultiWindowManage
   void SetFullscreen(int64_t id, bool fullscreen);
 
   void SetFrame(int64_t id, double_t x, double_t y, double_t width, double_t height);
-  g_autoptr(FlValue) GetFrame();
+  FlValue* GetFrame(int64_t id);
 
   void Center(int64_t id);
 

--- a/macos/Classes/FlutterMultiWindowPlugin.swift
+++ b/macos/Classes/FlutterMultiWindowPlugin.swift
@@ -63,6 +63,10 @@ public class FlutterMultiWindowPlugin: NSObject, FlutterPlugin {
       let rect = NSRect(x: left, y: top, width: width, height: height)
       MultiWindowManager.shared.setFrame(windowId: windowId, frame: rect)
       result(nil)
+    case "getFrame":
+      let arguments = call.arguments as! [String: Any?]
+      let windowId = arguments["windowId"] as! Int64
+      result(MultiWindowManager.shared.getFrame(windowId: windowId))
     case "setTitle":
       let arguments = call.arguments as! [String: Any?]
       let windowId = arguments["windowId"] as! Int64

--- a/macos/Classes/FlutterWindow.swift
+++ b/macos/Classes/FlutterWindow.swift
@@ -89,6 +89,18 @@ class BaseFlutterWindow: NSObject {
     window.setFrame(frame, display: false, animate: true)
   }
 
+  func GetFrame() -> NSDictionary {
+    let frameRect: NSRect = window.frame;
+    
+    let data: NSDictionary = [
+        "x": frameRect.topLeft.x,
+        "y": frameRect.topLeft.y,
+        "width": frameRect.size.width,
+        "height": frameRect.size.height,
+    ]
+    data
+  }
+
   func setTitle(title: String) {
     window.title = title
   }

--- a/macos/Classes/MultiWindowManager.swift
+++ b/macos/Classes/MultiWindowManager.swift
@@ -158,6 +158,14 @@ class MultiWindowManager {
     window.setFrame(frame: frame)
   }
 
+  func getFrame(windowId: Int64) -> NSDictionary {
+    guard let window = windows[windowId] else {
+      debugPrint("window \(windowId) not exists.")
+      return [];
+    }
+    window.getFrame(windowId: windowId)
+  }
+
   func setTitle(windowId: Int64, title: String) {
     guard let window = windows[windowId] else {
       debugPrint("window \(windowId) not exists.")

--- a/windows/base_flutter_window.cc
+++ b/windows/base_flutter_window.cc
@@ -312,6 +312,27 @@ void BaseFlutterWindow::SetBounds(double_t x, double_t y, double_t width, double
              TRUE);
 }
 
+flutter::EncodableMap BaseFlutterWindow::GetBounds() {
+  flutter::EncodableMap resultMap = flutter::EncodableMap();
+  auto handle = GetWindowHandle();
+  if (handle) {
+    RECT rect;
+    if (GetWindowRect(handle, &rect)) {
+      double x = rect.left;
+      double y = rect.top;
+      double width = (rect.right - rect.left);
+      double height = (rect.bottom - rect.top);
+      resultMap[flutter::EncodableValue("x")] = flutter::EncodableValue(x);
+      resultMap[flutter::EncodableValue("y")] = flutter::EncodableValue(y);
+      resultMap[flutter::EncodableValue("width")] =
+          flutter::EncodableValue(width);
+      resultMap[flutter::EncodableValue("height")] =
+          flutter::EncodableValue(height);
+    }
+  }
+  return resultMap;
+}
+
 void BaseFlutterWindow::SetTitle(const std::string &title) {
   auto handle = GetWindowHandle();
   if (!handle) {

--- a/windows/base_flutter_window.h
+++ b/windows/base_flutter_window.h
@@ -36,6 +36,7 @@ class BaseFlutterWindow {
   void Restore();
 
   void SetBounds(double_t x, double_t y, double_t width, double_t height);
+  flutter::EncodableMap GetBounds();
 
   void Center();
 

--- a/windows/desktop_multi_window_plugin.cpp
+++ b/windows/desktop_multi_window_plugin.cpp
@@ -80,6 +80,12 @@ void DesktopMultiWindowPlugin::HandleMethodCall(
     MultiWindowManager::Instance()->SetFrame(window_id, left, top, width, height);
     result->Success();
     return;
+  } else if (method_call.method_name() == "getFrame") {
+    auto *arguments = std::get_if<flutter::EncodableMap>(method_call.arguments());
+    auto window_id = arguments->at(flutter::EncodableValue("windowId")).LongValue();
+    flutter::EncodableMap value = MultiWindowManager::Instance()->GetFrame(window_id);
+    result->Success(flutter::EncodableValue(value));
+    return;
   } else if (method_call.method_name() == "center") {
     auto window_id = method_call.arguments()->LongValue();
     MultiWindowManager::Instance()->Center(window_id);

--- a/windows/multi_window_manager.cc
+++ b/windows/multi_window_manager.cc
@@ -115,6 +115,15 @@ void MultiWindowManager::SetFrame(int64_t id, double x, double y, double width, 
   }
 }
 
+flutter::EncodableMap MultiWindowManager::GetFrame(int64_t id) {
+  auto window = windows_.find(id);
+  if (window != windows_.end()) {
+    return window->second->GetBounds();
+  } else {
+    return flutter::EncodableMap();
+  }
+}
+
 void MultiWindowManager::SetTitle(int64_t id, const std::string &title) {
   auto window = windows_.find(id);
   if (window != windows_.end()) {

--- a/windows/multi_window_manager.h
+++ b/windows/multi_window_manager.h
@@ -46,6 +46,7 @@ class MultiWindowManager : public std::enable_shared_from_this<MultiWindowManage
   void Close(int64_t id);
 
   void SetFrame(int64_t id, double_t x, double_t y, double_t width, double_t height);
+  flutter::EncodableMap GetFrame(int64_t id);
 
   void Center(int64_t id);
 


### PR DESCRIPTION
Add interface [`getFrame()`](https://github.com/fufesou/rustdesk_desktop_multi_window/blob/3bcf550253783bdba4db760917ec617e3c0f2b52/lib/src/window_controller.dart#L59).

Tested on Win10 and Linux.
*Not tested* on MacOS.